### PR TITLE
Create swis.o (for project "switching.software")

### DIFF
--- a/zone/swis
+++ b/zone/swis
@@ -1,0 +1,2 @@
+swis  IN  A  157.245.6.117
+www.swis  IN  CNAME  swis.o.


### PR DESCRIPTION
I'm curious and want to try the swis.o domain for our project https://swiso.org (aka https://switching.software)